### PR TITLE
fix docker build output parser 

### DIFF
--- a/dmake/build.py
+++ b/dmake/build.py
@@ -212,15 +212,16 @@ class Build(object):
     def _do_build(self, params):
         response = self.docker.build(**params)
         image_id = None
-        for line in response:
-            ret = json.loads(line)
-            if 'stream' in ret:
-                msg = ret['stream']
-                LOG.debug("%s: %s" % (self.name, msg))
-            if 'errorDetail' in ret:
-                raise BuildFailed(ret['errorDetail']['message'])
-            if 'Successfully built' in ret.get('stream', ''):
-                image_id = ret['stream'].strip().split()[-1]
+        for data in response:
+            for line in data.splitlines():
+                ret = json.loads(line)
+                if 'stream' in ret:
+                    msg = ret['stream']
+                    LOG.debug("%s: %s" % (self.name, msg))
+                if 'errorDetail' in ret:
+                    raise BuildFailed(ret['errorDetail']['message'])
+                if 'Successfully built' in ret.get('stream', ''):
+                    image_id = ret['stream'].strip().split()[-1]
         return image_id
 
     def _do_push(self, repo, tag):

--- a/dmake/utils.py
+++ b/dmake/utils.py
@@ -41,7 +41,7 @@ def docker_client():
     if _docker is None:
         params = docker_utils.kwargs_from_env()
         params['version'] = 'auto'
-        _docker = docker.client.Client(**params)
+        _docker = docker.api.client.APIClient(**params)
     return _docker
 
 

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,2 +1,2 @@
 PyYAML >= 3.10, < 4
-docker-py >= 1.8.1, < 2
+docker >= 2.1.0, < 3


### PR DESCRIPTION
Docker must be outputting something different than whatever docker was outputting when this tool was last updated.  I was getting some output that had multiple json objects which resulted in ExtraData errors. 

This fixes those errors and also upgrades the `docker-py` dependency to the newer `docker 2.1.0` which meant changing how the util was creating its client. It seems to work fine otherwise and the tests all pass for me.