### PR TITLE
fix-no-tags - hush error output when there are no tags for the repo

### DIFF
--- a/dmake/template_args.py
+++ b/dmake/template_args.py
@@ -40,7 +40,7 @@ class ExternalCmdGenerator(TemplateArgsGenerator):
             # having 0 tags is not worthy of warning
             if isinstance(self, GitDescribeGenerator) and "No names found" in e.output:
                 log_level = logging.INFO
-            LOG.log(log_level, "failed to run %s: %s (%s)", self.cmd, e, e.output.strip())
+            LOG.log(log_level, "failed to run %s: %s", self.cmd, e)
             pass
 
 

--- a/dmake/template_args.py
+++ b/dmake/template_args.py
@@ -38,7 +38,8 @@ class ExternalCmdGenerator(TemplateArgsGenerator):
             log_level = logging.WARNING
 
             # having 0 tags is not worthy of warning
-            if isinstance(self, GitDescribeGenerator) and "No names found" in e.output:
+            if (isinstance(self, GitDescribeGenerator) and
+                    "No names found" in e.output):
                 log_level = logging.INFO
             LOG.log(log_level, "failed to run %s: %s", self.cmd, e)
             pass

--- a/dmake/template_args.py
+++ b/dmake/template_args.py
@@ -28,13 +28,19 @@ class ExternalCmdGenerator(TemplateArgsGenerator):
     def gen_args(self):
         try:
             value = subprocess.check_output(self.cmd,
+                                            stderr=subprocess.STDOUT,
                                             shell=not isinstance(self.cmd,
                                                                  list))
             value = value.strip()
             if value:
                 yield self.key, value.strip()
         except subprocess.CalledProcessError as e:
-            LOG.warn("failed to run %s: %s", self.cmd, e)
+            log_level = logging.WARNING
+
+            # having 0 tags is not worthy of warning
+            if isinstance(self, GitDescribeGenerator) and "No names found" in e.output:
+                log_level = logging.INFO
+            LOG.log(log_level, "failed to run %s: %s (%s)", self.cmd, e, e.output.strip())
             pass
 
 

--- a/tests/test_template_args.py
+++ b/tests/test_template_args.py
@@ -31,7 +31,7 @@ class ExternalCmdGeneratorTests(unittest2.TestCase):
         k, v = args
         self.assertEqual(k, 'dummy')
         self.assertEqual(v, 'dummy')
-        mocked_check_output.assert_called_once_with('echo dummy', shell=True)
+        mocked_check_output.assert_called_once_with('echo dummy', shell=True, stderr=-2)
 
     @mock.patch('subprocess.check_output', return_value=' dummy ')
     def test_key_cmd_in_init(self, mocked_check_output):
@@ -41,21 +41,21 @@ class ExternalCmdGeneratorTests(unittest2.TestCase):
         k, v = args
         self.assertEqual(k, 'dummy')
         self.assertEqual(v, 'dummy')
-        mocked_check_output.assert_called_once_with('echo dummy', shell=True)
+        mocked_check_output.assert_called_once_with('echo dummy', shell=True, stderr=-2)
 
     @mock.patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(-1, 'echo dummy'))
     def test_raise_call_error(self, mocked_check_output):
         key, cmd = 'dummy', 'echo dummy'
         args = next(template_args.ExternalCmdGenerator(key, cmd).gen_args(), None)
         self.assertIsNone(args)
-        mocked_check_output.assert_called_once_with('echo dummy', shell=True)
+        mocked_check_output.assert_called_once_with('echo dummy', shell=True, stderr=-2)
 
     @mock.patch('subprocess.check_output', return_value=' ')
     def test_blank_output(self, mocked_check_output):
         key, cmd = 'dummy', 'echo dummy'
         args = next(template_args.ExternalCmdGenerator(key, cmd).gen_args(), None)
         self.assertIsNone(args)
-        mocked_check_output.assert_called_once_with('echo dummy', shell=True)
+        mocked_check_output.assert_called_once_with('echo dummy', shell=True, stderr=-2)
 
 
 class GitGeneratorsTests(unittest2.TestCase):
@@ -65,7 +65,7 @@ class GitGeneratorsTests(unittest2.TestCase):
         k1, v1 = next(pairs)
         self.assertEqual(k1, 'fcommitid')
         self.assertEqual(v1, '56903369fd200ea021dbb75f357f94b7fb5e829e')
-        mocked_check_output.assert_called_once_with('git rev-parse HEAD', shell=True)
+        mocked_check_output.assert_called_once_with('git rev-parse HEAD', shell=True, stderr=-2)
 
         k2, v2 = next(pairs)
         self.assertEqual(k2, 'scommitid')
@@ -76,28 +76,31 @@ class GitGeneratorsTests(unittest2.TestCase):
         k, v = next(template_args.GitCommitMsgGenerator().gen_args())
         self.assertEqual(k, 'commitmsg')
         self.assertEqual(v, '5690336 refactor and add unit tests.')
-        mocked_check_output.assert_called_once_with('git log --oneline|head -1', shell=True)
+        mocked_check_output.assert_called_once_with('git log --oneline|head -1', shell=True,
+                                                    stderr=-2)
 
     @mock.patch('subprocess.check_output', return_value='master')
     def test_git_branch(self, mocked_check_output):
         k, v = next(template_args.GitBranchGenerator().gen_args())
         self.assertEqual(k, 'git_branch')
         self.assertEqual(v, 'master')
-        mocked_check_output.assert_called_once_with('git rev-parse --abbrev-ref HEAD', shell=True)
+        mocked_check_output.assert_called_once_with('git rev-parse --abbrev-ref HEAD', shell=True,
+                                                    stderr=-2)
 
     @mock.patch('subprocess.check_output', return_value='1.11.3')
     def test_git_tag(self, mocked_check_output):
         k, v = next(template_args.GitTagGenerator().gen_args())
         self.assertEqual(k, 'git_tag')
         self.assertEqual(v, '1.11.3')
-        mocked_check_output.assert_called_once_with('git tag --contains HEAD|head -1', shell=True)
+        mocked_check_output.assert_called_once_with('git tag --contains HEAD|head -1', shell=True,
+                                                    stderr=-2)
 
     @mock.patch('subprocess.check_output', return_value='1.1.2-5-g5690336')
     def test_git_describe(self, mocked_check_output):
         k, v = next(template_args.GitDescribeGenerator().gen_args())
         self.assertEqual(k, 'git_describe')
         self.assertEqual(v, '1.1.2-5-g5690336')
-        mocked_check_output.assert_called_once_with('git describe --tags', shell=True)
+        mocked_check_output.assert_called_once_with('git describe --tags', shell=True, stderr=-2)
 
 
 class ArgsExportingFunctionTests(unittest2.TestCase):


### PR DESCRIPTION
Also, include the command error output in the warning message rather than mixed in where subprocess is executed