### PR TITLE
Added support for removing intermediate containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ With java and php as the base images, a java app and a php app are built.
 
 ```bash
 $ docker-make --help
-usage: docker-make [-h] [-f DMAKEFILE] [-d] [--dry-run] [--no-push]
+usage: docker-make [-h] [-f DMAKEFILE] [-d] [-rm] [--dry-run] [--no-push]
                    [builds [builds ...]]
 
 build docker images in a simpler way.
@@ -239,6 +239,7 @@ optional arguments:
   -f DMAKEFILE, --file DMAKEFILE
                         path to docker-make configuration file.
   -d, --detailed        print out detailed logs
+  -rm, --remove         remove intermediate containers
   --dry-run             print docker commands only
   --no-push             build only, dont push
 ```

--- a/dmake/build.py
+++ b/dmake/build.py
@@ -16,7 +16,8 @@ LOG = logging.getLogger(__name__)
 class Build(object):
     def __init__(self, name, context, dockerfile,
                  dockerignore=None, labels=None, depends_on=None,
-                 extract=None, pushes=None, rewrite_from=None, remove_intermediate=None):
+                 extract=None, pushes=None, rewrite_from=None,
+                 remove_intermediate=None):
         self.name = name
         self.context = os.path.join(os.getcwd(), context.lstrip('/'))
         self.dockerfile = dockerfile

--- a/dmake/build.py
+++ b/dmake/build.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 class Build(object):
     def __init__(self, name, context, dockerfile,
                  dockerignore=None, labels=None, depends_on=None,
-                 extract=None, pushes=None, rewrite_from=None):
+                 extract=None, pushes=None, rewrite_from=None, remove_intermediate=None):
         self.name = name
         self.context = os.path.join(os.getcwd(), context.lstrip('/'))
         self.dockerfile = dockerfile
@@ -25,6 +25,7 @@ class Build(object):
             self.dockerignore.append('.dockerignore')
         self.depends_on = depends_on or []
         self.rewrite_from = rewrite_from
+        self.remove_intermediate = remove_intermediate
 
         self.collect_pushes(pushes)
         self.collect_labels(labels)
@@ -182,6 +183,10 @@ class Build(object):
             'dockerfile': self.dockerfile,
         }
 
+        if self.remove_intermediate:
+            LOG.debug("Removing intermediate containers after each build")
+            params['rm'] = self.remove_intermediate
+
         try:
             image_id = self._do_build(params)
         finally:
@@ -201,6 +206,10 @@ class Build(object):
         params = {
             'fileobj': pfile,
         }
+
+        if self.remove_intermediate:
+            LOG.debug("Removing intermediate containers after each build")
+            params['rm'] = self.remove_intermediate
 
         try:
             image_id = self._do_build(params)

--- a/dmake/cli.py
+++ b/dmake/cli.py
@@ -18,6 +18,8 @@ def argparser():
                         help='path to docker-make configuration file.')
     parser.add_argument('-d', '--detailed', default=False,
                         action='store_true', help='print out detailed logs')
+    parser.add_argument('-rm', '--remove', default=False,
+                        action='store_true', help='remove intermediate containers')
     parser.add_argument('--dry-run', dest='dryrun', action='store_true',
                         default=False, help='print docker commands only')
     parser.add_argument('--no-push', dest='nopush', action='store_true',
@@ -51,6 +53,8 @@ def _main():
 
     builds = {}
     for name in builds_order:
+        if (args.remove):
+            builds_dict[name]['remove_intermediate'] = args.remove
         builds[name] = dmake.build.Build(name=name, **builds_dict[name])
 
     if args.builds:

--- a/dmake/cli.py
+++ b/dmake/cli.py
@@ -19,7 +19,8 @@ def argparser():
     parser.add_argument('-d', '--detailed', default=False,
                         action='store_true', help='print out detailed logs')
     parser.add_argument('-rm', '--remove', default=False,
-                        action='store_true', help='remove intermediate containers')
+                        action='store_true',
+                        help='remove intermediate containers')
     parser.add_argument('--dry-run', dest='dryrun', action='store_true',
                         default=False, help='print docker commands only')
     parser.add_argument('--no-push', dest='nopush', action='store_true',


### PR DESCRIPTION
Added `-rm/--remove` parameter to `docker-make`, which enables removing intermediate containers while building, labeling etc.

While it's not the universal Docker parameter solution we discussed in #11, it at least allows for cleaner builds.